### PR TITLE
Make levitation and flying confer immunity to floor traps

### DIFF
--- a/src/cmd1.cc
+++ b/src/cmd1.cc
@@ -661,6 +661,12 @@ static void hit_trap(void)
 
 	cave_type *c_ptr;
 
+	/* Skip traps if flying/levitating */
+	if (p_ptr->ffall || p_ptr->fly)
+	{
+		msg_print("You float over the trap.");
+		return;
+	}
 
 	/* Disturb the player */
 	disturb(0);

--- a/src/cmd2.cc
+++ b/src/cmd2.cc
@@ -1922,9 +1922,15 @@ static bool_ do_cmd_disarm_aux(int y, int x, int dir, int do_pickup)
 
 	bool_ more = FALSE;
 
-
 	/* Take a turn */
 	energy_use = 100;
+
+	/* If floating or flying, we can just move over it */
+	if (p_ptr->ffall || p_ptr->fly)
+	{
+		move_player_aux(dir, do_pickup, 0, FALSE);
+		return (more);
+	}
 
 	/* Get grid and contents */
 	c_ptr = &cave[y][x];
@@ -1997,7 +2003,6 @@ static bool_ do_cmd_disarm_aux(int y, int x, int dir, int do_pickup)
 	/* Failure -- Set off the trap */
 	else
 	{
-		/* Message */
 		msg_format("You set off the %s!", name);
 
 		/* Move the player onto the trap */


### PR DESCRIPTION
Characters who are floating or flying will now automatically "float over" any floor trap, rather than blundering into or attempting to disarm it. The implementation is a tad hackish, but it does the job, and makes floor traps less of an issue.