### PR TITLE
Fix the far-reaching attack skill

### DIFF
--- a/src/skills.cc
+++ b/src/skills.cc
@@ -1114,7 +1114,7 @@ void do_cmd_activate_skill()
 		int dir, dy, dx, targetx, targety, max_blows, flags;
 
 		o_ptr = get_object(INVEN_WIELD);
-		if (o_ptr->tval == TV_POLEARM)
+		if (o_ptr->tval != TV_POLEARM)
 		{
 			msg_print("You will need a long polearm for this!");
 			return;


### PR DESCRIPTION
The far-reaching attack function exited when it found that a polearm was wielded, rather than when a polearm was *not* wielded. This fixes the logic and makes far-reaching attack work again (for whatever that is worth).