### PR TITLE
Fix path traversal in screenshot and character dump

### DIFF
--- a/src/cmd3.cc
+++ b/src/cmd3.cc
@@ -1826,7 +1826,7 @@ void do_cmd_html_dump()
 	if (html)
 	{
 		strcpy(tmp_val, "dummy.htm");
-		if (!get_string("File(you can post it to http://angband.oook.cz/): ", tmp_val, 80))
+		if (!get_filename("File(you can post it to http://angband.oook.cz/): ", tmp_val, 80))
 		{
 			/* Now restore the screen to initial state */
 			Term_load_from(save);
@@ -1837,7 +1837,7 @@ void do_cmd_html_dump()
 	else
 	{
 		strcpy(tmp_val, "dummy.txt");
-		if (!get_string("File: ", tmp_val, 80))
+		if (!get_filename("File: ", tmp_val, 80))
 		{
 			/* Now restore the screen to initial state */
 			Term_load_from(save);

--- a/src/cmd4.cc
+++ b/src/cmd4.cc
@@ -181,7 +181,7 @@ void do_cmd_change_name(void)
 		else if (c == 'f')
 		{
 			strnfmt(tmp, 160, "%s.txt", player_name);
-			if (get_string("Filename(you can post it to http://angband.oook.cz/): ", tmp, 80))
+			if (get_filename("Filename(you can post it to http://angband.oook.cz/): ", tmp, 80))
 			{
 				if (tmp[0] && (tmp[0] != ' '))
 				{

--- a/src/util.cc
+++ b/src/util.cc
@@ -2539,7 +2539,7 @@ bool_ get_string(cptr prompt, char *buf, int len)
 }
 
 /* Get a safe filename */
-bool_ get_filename(cptr prompt, char *buf, int len)
+extern bool_ get_filename(cptr prompt, char *buf, int len)
 {
 	bool_ res;
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -26,11 +26,13 @@
 #include "xtra1.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem/path.hpp>
 #include <chrono>
 #include <sstream>
 #include <thread>
 
 using boost::algorithm::iequals;
+using boost::filesystem::portable_name;
 using std::this_thread::sleep_for;
 using std::chrono::milliseconds;
 
@@ -2533,6 +2535,21 @@ bool_ get_string(cptr prompt, char *buf, int len)
 	prt("", 0, 0);
 
 	/* Result */
+	return (res);
+}
+
+/* Get a safe filename */
+bool_ get_filename(cptr prompt, char *buf, int len)
+{
+	bool_ res;
+
+	res = get_string(prompt, buf, len);
+
+	if (!portable_name(buf))
+	{
+		res = false;
+	}
+
 	return (res);
 }
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -53,6 +53,7 @@ extern bool askfor_aux(std::string *buf, std::size_t max_len);
 extern bool_ askfor_aux(char *buf, int len);
 extern bool_ askfor_aux_with_completion(char *buf, int len);
 extern bool_ get_string(cptr prompt, char *buf, int len);
+extern bool_ get_filename(cptr prompt, char *buf, int len);
 extern bool_ get_check(cptr prompt);
 extern bool_ get_com(cptr prompt, char *command);
 extern s32b get_quantity(cptr prompt, s32b max);


### PR DESCRIPTION
I'd like to start patching security vulnerabilities so that tome can be played on a multiuser system. Reviewing potential buffer overflows could take a while, but some of the more obvious path traversals can be easily fixed. Here is a patch for screenshot and character sheet creation. There are others, (e.g., in the automatizer) but askfor_aux() is a little more complicated, so I haven't tackled it yet.