### PR TITLE
Remove sys/timeb.h include

### DIFF
--- a/src/h-system.h
+++ b/src/h-system.h
@@ -29,8 +29,6 @@
 #  include <sys/time.h>
 # endif
 
-#  include <sys/timeb.h>
-
 #endif
 
 


### PR DESCRIPTION
Termux doesn't have sys/timeb.h, so current master won't build on it without that include removed. Tome2 currently doesn't seem to use ftime() or the timeb struct anywhere, so it seems reasonable to me to just remove this include to support Termux.