### PR TITLE
Corruption crash fix

### DIFF
--- a/src/corrupt.cc
+++ b/src/corrupt.cc
@@ -31,8 +31,8 @@ struct corruption_type
 	const char *get_text;
 	const char *lose_text; /* If NULL, the corruption is NOT removable by any means */
 	const char *desc;
-	s16b depends[5];
-	s16b opposes[5];
+	s16b depends[5]; /* terminated by a -1 entry */
+	s16b opposes[5]; /* terminated by a -1 entry */
 	void (*gain_callback)(); /* callback to invoke when gained */
 	s16b power;              /* index of granted power if >= 0, ignored otherwise */
 };

--- a/src/corrupt.cc
+++ b/src/corrupt.cc
@@ -31,8 +31,8 @@ struct corruption_type
 	const char *get_text;
 	const char *lose_text; /* If NULL, the corruption is NOT removable by any means */
 	const char *desc;
-	s16b depends[5]; /* terminated by a -1 entry */
-	s16b opposes[5]; /* terminated by a -1 entry */
+	s16b depends[5];
+	s16b opposes[5];
 	void (*gain_callback)(); /* callback to invoke when gained */
 	s16b power;              /* index of granted power if >= 0, ignored otherwise */
 };

--- a/src/corrupt.cc
+++ b/src/corrupt.cc
@@ -823,8 +823,7 @@ static bool test_depend_corrupt(s16b corrupt_idx, bool can_gain)
 	}
 
 	/* Go through all dependencies */
-	for (i=0; i < sizeof(c_ptr->depends)/sizeof(c_ptr->depends[0])
-			&& c_ptr->depends[i] >= 0; i++)
+	for (i=0; (i < std::size(c_ptr->depends) && c_ptr->depends[i] >= 0; i++)
 	{
 		if (!test_depend_corrupt(c_ptr->depends[i], false))
 		{
@@ -833,8 +832,7 @@ static bool test_depend_corrupt(s16b corrupt_idx, bool can_gain)
 	}
 
 	/* Go through all opposers */
-	for (i=0; i < sizeof(c_ptr->depends)/sizeof(c_ptr->depends[0])
-			&& c_ptr->opposes[i] >= 0; i++)
+	for (i=0; i < std::size(c_ptr->depends) && c_ptr->opposes[i] >= 0; i++)
 	{
 		if (test_depend_corrupt(c_ptr->opposes[i], false))
 		{

--- a/src/corrupt.cc
+++ b/src/corrupt.cc
@@ -801,7 +801,7 @@ static void player_lose_corruption(int corruption_idx)
  */
 static bool test_depend_corrupt(s16b corrupt_idx, bool can_gain)
 {
-	s16b i;
+	size_t i;
 	corruption_type *c_ptr = NULL;
 
 	assert(corrupt_idx >= 0);
@@ -823,7 +823,8 @@ static bool test_depend_corrupt(s16b corrupt_idx, bool can_gain)
 	}
 
 	/* Go through all dependencies */
-	for (i=0; c_ptr->depends[i] >= 0; i++)
+	for (i=0; i < sizeof(c_ptr->depends)/sizeof(c_ptr->depends[0])
+			&& c_ptr->depends[i] >= 0; i++)
 	{
 		if (!test_depend_corrupt(c_ptr->depends[i], false))
 		{
@@ -832,7 +833,8 @@ static bool test_depend_corrupt(s16b corrupt_idx, bool can_gain)
 	}
 
 	/* Go through all opposers */
-	for (i=0; c_ptr->opposes[i] >= 0; i++)
+	for (i=0; i < sizeof(c_ptr->depends)/sizeof(c_ptr->depends[0])
+			&& c_ptr->opposes[i] >= 0; i++)
 	{
 		if (test_depend_corrupt(c_ptr->opposes[i], false))
 		{


### PR DESCRIPTION
Fixes intermittent out-of-bounds crashes when searching through dependent and opposing corruptions. There are comments to the effect that the depends[] and opposes[] arrays are terminated with -1 values, but this doesn't seem to be true anymore (or at least not reliably); so I've added bounds checks (and changed the index to a size_t to avoid warnings), but otherwise left the code unchanged.