### PR TITLE
A couple of bug fixes

### DIFF
--- a/lib/help/wishing.txt
+++ b/lib/help/wishing.txt
@@ -10,11 +10,12 @@ Due to the powerful nature of wishes, there are some rules that govern
 what is able to be wished for. These rules are as follows:
 1. You cannot wish for a wish, or any other item which would grant more
    wishes.
-2. A wish will always generate *one* object. So, never put a number, "a"
+2. A wish will always generate *one* object. The name must be typed EXACTLY
+   as it would appear as an item (case insensitive). So, never put a number, "a"
    or "an" in front of the object you are wishing for.
 3. It is not possible to wish for the magical +'s to the object (i.e. you
-   cannot wish for "gloves of slaying (+10,+10)", but you can wish for 
-   "gloves of slaying").
+   cannot wish for "set of leather gloves of slaying (+10,+10)", but you can wish for 
+   "set of leather gloves of slaying").
 4. You cannot wish for artifacts, but you *can* wish for excellent (ego)
    items.
 5. You can wish for monsters and ego monsters (e.g. "cave orc", "rogue cave

--- a/src/cmd5.cc
+++ b/src/cmd5.cc
@@ -1882,7 +1882,8 @@ bool is_ok_spell(s32b spell_idx, s32b pval)
 	}
 	// Are we permitted to cast based on item pval? Only music
 	// spells have non-zero minimum PVAL.
-	if (pval < spell_type_minimum_pval(spell))
+	s32b min_pval = spell_type_minimum_pval(spell);
+	if (min_pval > 0 && pval < min_pval)
 	{
 		return false;
 	}
@@ -2035,7 +2036,6 @@ s32b get_school_spell(const char *do_what, s16b force_book)
 			{
 				/* Save the spell index */
 				spell = spell_x(sval, pval, i);
-
 				/* Require "okay" spells */
 				if (!is_ok_spell(spell, o_ptr->pval))
 				{

--- a/src/spells3.cc
+++ b/src/spells3.cc
@@ -3561,8 +3561,10 @@ const char *device_haste_monster_info()
 
 casting_result device_wish()
 {
-	make_wish();
-	return CAST;
+	if (make_wish()) {
+		return CAST;
+	}
+	return NO_CAST;
 }
 
 casting_result device_summon_monster()

--- a/src/xtra2.cc
+++ b/src/xtra2.cc
@@ -5183,7 +5183,7 @@ static void clean_wish_name(char *buf, char *name)
 /*
  * Allow the player to make a wish
  */
-void make_wish()
+bool_ make_wish()
 {
 	auto const &re_info = game->edit_data.re_info;
 	auto const &r_info = game->edit_data.r_info;
@@ -5197,7 +5197,7 @@ void make_wish()
 	buf[0] = 0;
 
 	/* Ask for the wish */
-	if (!get_string("Wish for what? ", buf, 80)) return;
+	if (!get_string("Wish for what? ", buf, 80)) return FALSE;
 
 	clean_wish_name(buf, name);
 
@@ -5205,7 +5205,7 @@ void make_wish()
 	if (strstr(name, "wish"))
 	{
 		msg_print("You can't wish for a wish!");
-		return;
+		return FALSE;
 	}
 
 	if (test_object_wish(name, o_ptr, &forge, "wish"))
@@ -5215,7 +5215,7 @@ void make_wish()
 		/* Give it to the player */
 		drop_near(o_ptr, -1, p_ptr->py, p_ptr->px);
 
-		return;
+		return TRUE;
 	}
 
 	/* try monsters */
@@ -5310,7 +5310,7 @@ void make_wish()
 					}
 
 					/* Don't search any more */
-					return;
+					return TRUE;
 				}
 			}
 		}

--- a/src/xtra2.cc
+++ b/src/xtra2.cc
@@ -5315,6 +5315,7 @@ bool_ make_wish()
 			}
 		}
 	}
+	return FALSE;
 }
 
 

--- a/src/xtra2.hpp
+++ b/src/xtra2.hpp
@@ -78,7 +78,7 @@ bool_ set_tim_esp(int v);
 bool_ tgp_pt(int *x, int * y);
 bool_ tgt_pt (int *x, int *y);
 void do_poly_self();
-void make_wish();
+bool_ make_wish();
 void create_between_gate(int dist, int y, int x);
 
 extern "C" {


### PR DESCRIPTION
Fixes for two bugs I noticed: 
1. If there is an item with a negative pvalue that can cast spells. (For example a deamonhorn) the spells were always unavailable even when they should be unlocked. This was due to a check meant to apply to music spells being applied.
2. When wishing the possible items are generated and compared against what the user typed. However when generating the items, it goes through the normal path as though they were loot. So some of them would randomly be upgraded by adding an extra ego status or getting turned into artifacts. However when this happens the name of the generated value would be affected causing the comparison to fail. There was also an bug related to double ego items which were not properly handled. In both cases the user did nothing wrong, but would loose their wish with no clear reason as to why. Both of these bugs are fixed and the wish function now returns a boolean so that it will not count as having been cast if it was not able to identify an item corresponding to what the user typed.