### PR TITLE
Fix build failure with GCC 10

### DIFF
--- a/src/init1.hpp
+++ b/src/init1.hpp
@@ -3,6 +3,8 @@
 #include "h-basic.hpp"
 #include "dungeon_flag_set.hpp"
 
+#include <cstdio>
+
 int color_char_to_attr(char c);
 extern byte conv_color[16];
 errr init_player_info_txt(FILE *fp);


### PR DESCRIPTION
FILE was not declared.

See also: https://bugs.debian.org/966065