### PR TITLE
Fix loading macros, see #51

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -758,7 +758,13 @@ static void trigger_text_to_ascii(char **bufptr, const char **strptr)
 	for (i = 0; i < max_macrotrigger; i++)
 	{
 		len = strlen(macro_trigger_name[i]);
-		if (iequals(str, macro_trigger_name[i]) && ']' == str[len])
+		char tstr[34];
+		memset(tstr,'\0',sizeof(tstr));
+		strncpy(tstr,str,32); // assume the keycode isn't longer than 32
+		if(strlen(tstr) > 0) { // assuming we actually copied something, trim of the ] at the end.
+			tstr[strlen(tstr)-1]='\0';
+		}
+		if (iequals(tstr, macro_trigger_name[i]) && ']' == str[len])
 		{
 			/* a trigger name found */
 			break;


### PR DESCRIPTION
The old code used to compare F1] to F1 and would therefor always fail. I am not an expert c coder and I am fairly certain that there should be a better way of doing what this commit does. I also think that most of the text_to_ascii and ascii_to_text code is in dire need of a cleanup.

At least with this change I am able to play the game without having to
redo my macros at the start of every session.