### PR TITLE
Fix handling multiple spell effects

### DIFF
--- a/src/cave.cc
+++ b/src/cave.cc
@@ -4199,24 +4199,30 @@ int is_quest(int level)
 boost::optional<s16b> new_effect(int type, int dam, int time, int cy, int cx, int rad, s32b flags)
 {
 	auto &lasting_effects = game->lasting_effects;
+	size_t max_lasting_effects = std::size(game->lasting_effects);
 
-	// Limit to 128 effects at most.
-	if (lasting_effects.size() >= 128)
+	std::size_t ei;
+	for (ei = 0; ei < max_lasting_effects; ei++)
+	{
+		if (lasting_effects[ei].time == 0)
+		{
+			break;
+		}
+	}
+	if (ei == max_lasting_effects)
 	{
 		return boost::none;
 	}
 
-	effect_type effect;
-	effect.type = type;
-	effect.dam = dam;
-	effect.time = time;
-	effect.flags = flags;
-	effect.cx = cx;
-	effect.cy = cy;
-	effect.rad = rad;
+	lasting_effects[ei].type = type;
+	lasting_effects[ei].dam = dam;
+	lasting_effects[ei].time = time;
+	lasting_effects[ei].flags = flags;
+	lasting_effects[ei].cx = cx;
+	lasting_effects[ei].cy = cy;
+	lasting_effects[ei].rad = rad;
 
-	lasting_effects.push_back(effect);
-	return lasting_effects.size() - 1;
+	return ei;
 }
 
 /**

--- a/src/dungeon.cc
+++ b/src/dungeon.cc
@@ -725,6 +725,7 @@ static bool is_light_safe(object_type const *o_ptr)
 static void process_lasting_effects()
 {
 	auto &lasting_effects = game->lasting_effects;
+	size_t max_lasting_effects = std::size(game->lasting_effects);
 
 	for (int j = 0; j < cur_hgt - 1; j++)
 	{
@@ -762,183 +763,201 @@ static void process_lasting_effects()
 		}
 	}
 
-	// Filter out any expired effects
-	lasting_effects.erase(
-		std::remove_if(
-			std::begin(lasting_effects),
-			std::end(lasting_effects),
-			[](auto effect) { return effect.time == 0; }),
-		std::end(lasting_effects));
-
 	// Reduce & handle effects
-	for (std::size_t i = 0; i < lasting_effects.size(); i++)
+	for (std::size_t i = 0; i < max_lasting_effects; i++)
 	{
 		effect_type &e = lasting_effects[i];
 
-		// Reduce duration
-		e.time--;
-
-		// Set up the effect in the dungeon.
-		if (e.flags & EFF_WAVE)
+		if (e.time > 0)
 		{
-			// Expand the wave front
-			e.rad++;
+			// Reduce duration
+			e.time--;
 
-			// Check direction
-			if (e.flags & EFF_DIR8)
+			// Set up the effect in the dungeon.
+			if (e.flags & EFF_WAVE)
 			{
-				for (int y = e.cy - e.rad, z = 0; y <= e.cy; y++, z++)
-				{
-					for (int x = e.cx - (e.rad - z); x <= e.cx + (e.rad - z); x++)
-					{
-						if (!in_bounds(y, x))
-						{
-							continue;
-						}
+				// Expand the wave front
+				e.rad++;
 
-						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
+				// Check direction
+				if (e.flags & EFF_DIR8)
+				{
+					for (int y = e.cy - e.rad, z = 0; y <= e.cy; y++, z++)
+					{
+						for (int x = e.cx - (e.rad - z); x <= e.cx + (e.rad - z); x++)
 						{
-							cave[y][x].maybe_effect = i;
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
+						}
+					}
+				}
+				else if (e.flags & EFF_DIR2)
+				{
+					for (int y = e.cy, z = e.rad; y <= e.cy + e.rad; y++, z--)
+					{
+						for (int x = e.cx - (e.rad - z); x <= e.cx + (e.rad - z); x++)
+						{
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
+						}
+					}
+				}
+				else if (e.flags & EFF_DIR6)
+				{
+					for (int x = e.cx, z = e.rad; x <= e.cx + e.rad; x++, z--)
+					{
+						for (int y = e.cy - (e.rad - z); y <= e.cy + (e.rad - z); y++)
+						{
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
+						}
+					}
+				}
+				else if (e.flags & EFF_DIR4)
+				{
+					for (int x = e.cx - e.rad, z = 0; x <= e.cx; x++, z++)
+					{
+						for (int y = e.cy - (e.rad - z); y <= e.cy + (e.rad - z); y++)
+						{
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
+						}
+					}
+				}
+				else if (e.flags & EFF_DIR9)
+				{
+					for (int y = e.cy - e.rad; y <= e.cy; y++)
+					{
+						for (int x = e.cx; x <= e.cx + e.rad; x++)
+						{
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
+						}
+					}
+				}
+				else if (e.flags & EFF_DIR1)
+				{
+					for (int y = e.cy; y <= e.cy + e.rad; y++)
+					{
+						for (int x = e.cx - e.rad; x <= e.cx; x++)
+						{
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
+						}
+					}
+				}
+				else if (e.flags & EFF_DIR7)
+				{
+					for (int y = e.cy - e.rad; y <= e.cy; y++)
+					{
+						for (int x = e.cx - e.rad; x <= e.cx; x++)
+						{
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
+						}
+					}
+				}
+				else if (e.flags & EFF_DIR3)
+				{
+					for (int y = e.cy; y <= e.cy + e.rad; y++)
+					{
+						for (int x = e.cx; x <= e.cx + e.rad; x++)
+						{
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
+						}
+					}
+				}
+				else
+				{
+					for (int y = e.cy - e.rad; y <= e.cy + e.rad; y++)
+					{
+						for (int x = e.cx - e.rad; x <= e.cx + e.rad; x++)
+						{
+							if (!in_bounds(y, x))
+							{
+								continue;
+							}
+
+							if (los(e.cy, e.cx, y, x) &&
+									(distance(e.cy, e.cx, y, x) == e.rad))
+							{
+								cave[y][x].maybe_effect = i;
+							}
 						}
 					}
 				}
 			}
-			else if (e.flags & EFF_DIR2)
+			else if (e.flags & EFF_STORM)
 			{
-				for (int y = e.cy, z = e.rad; y <= e.cy + e.rad; y++, z--)
-				{
-					for (int x = e.cx - (e.rad - z); x <= e.cx + (e.rad - z); x++)
-					{
-						if (!in_bounds(y, x))
-						{
-							continue;
-						}
-
-						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
-						{
-							cave[y][x].maybe_effect = i;
-						}
-					}
-				}
-			}
-			else if (e.flags & EFF_DIR6)
-			{
-				for (int x = e.cx, z = e.rad; x <= e.cx + e.rad; x++, z--)
-				{
-					for (int y = e.cy - (e.rad - z); y <= e.cy + (e.rad - z); y++)
-					{
-						if (!in_bounds(y, x))
-						{
-							continue;
-						}
-
-						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
-						{
-							cave[y][x].maybe_effect = i;
-						}
-					}
-				}
-			}
-			else if (e.flags & EFF_DIR4)
-			{
-				for (int x = e.cx - e.rad, z = 0; x <= e.cx; x++, z++)
-				{
-					for (int y = e.cy - (e.rad - z); y <= e.cy + (e.rad - z); y++)
-					{
-						if (!in_bounds(y, x))
-						{
-							continue;
-						}
-
-						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
-						{
-							cave[y][x].maybe_effect = i;
-						}
-					}
-				}
-			}
-			else if (e.flags & EFF_DIR9)
-			{
-				for (int y = e.cy - e.rad; y <= e.cy; y++)
-				{
-					for (int x = e.cx; x <= e.cx + e.rad; x++)
-					{
-						if (!in_bounds(y, x))
-						{
-							continue;
-						}
-
-						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
-						{
-							cave[y][x].maybe_effect = i;
-						}
-					}
-				}
-			}
-			else if (e.flags & EFF_DIR1)
-			{
-				for (int y = e.cy; y <= e.cy + e.rad; y++)
-				{
-					for (int x = e.cx - e.rad; x <= e.cx; x++)
-					{
-						if (!in_bounds(y, x))
-						{
-							continue;
-						}
-
-						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
-						{
-							cave[y][x].maybe_effect = i;
-						}
-					}
-				}
-			}
-			else if (e.flags & EFF_DIR7)
-			{
-				for (int y = e.cy - e.rad; y <= e.cy; y++)
-				{
-					for (int x = e.cx - e.rad; x <= e.cx; x++)
-					{
-						if (!in_bounds(y, x))
-						{
-							continue;
-						}
-
-						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
-						{
-							cave[y][x].maybe_effect = i;
-						}
-					}
-				}
-			}
-			else if (e.flags & EFF_DIR3)
-			{
-				for (int y = e.cy; y <= e.cy + e.rad; y++)
-				{
-					for (int x = e.cx; x <= e.cx + e.rad; x++)
-					{
-						if (!in_bounds(y, x))
-						{
-							continue;
-						}
-
-						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
-						{
-							cave[y][x].maybe_effect = i;
-						}
-					}
-				}
-			}
-			else
-			{
+				// Center on player
+				e.cy = p_ptr->py;
+				e.cx = p_ptr->px;
+				// Set up the effect
 				for (int y = e.cy - e.rad; y <= e.cy + e.rad; y++)
 				{
 					for (int x = e.cx - e.rad; x <= e.cx + e.rad; x++)
@@ -949,34 +968,11 @@ static void process_lasting_effects()
 						}
 
 						if (los(e.cy, e.cx, y, x) &&
-								(distance(e.cy, e.cx, y, x) == e.rad))
+								(distance(e.cy, e.cx, y, x) <= e.rad))
 						{
 							cave[y][x].maybe_effect = i;
+							lite_spot(y, x);
 						}
-					}
-				}
-			}
-		}
-		else if (e.flags & EFF_STORM)
-		{
-			// Center on player
-			e.cy = p_ptr->py;
-			e.cx = p_ptr->px;
-			// Set up the effect
-			for (int y = e.cy - e.rad; y <= e.cy + e.rad; y++)
-			{
-				for (int x = e.cx - e.rad; x <= e.cx + e.rad; x++)
-				{
-					if (!in_bounds(y, x))
-					{
-						continue;
-					}
-
-					if (los(e.cy, e.cx, y, x) &&
-							(distance(e.cy, e.cx, y, x) <= e.rad))
-					{
-						cave[y][x].maybe_effect = i;
-						lite_spot(y, x);
 					}
 				}
 			}

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -114,7 +114,7 @@ struct Game {
 	/**
 	 * Lasting effects.
 	 */
-	std::vector<effect_type> lasting_effects { };
+	effect_type lasting_effects[128];
 
 	/**
 	 * Generate a special level feeling?

--- a/src/generate.cc
+++ b/src/generate.cc
@@ -8095,7 +8095,9 @@ static void generate_grid_mana()
 static void clear_dungeon()
 {
 	/* Clear any lasting effects */
-	game->lasting_effects.clear();
+	for (std::size_t i = 0; i < std::size(game->lasting_effects); i++) {
+		game->lasting_effects[i].time = 0;
+	}
 
 	/* Start with a blank cave */
 	for (int y = 0; y < MAX_HGT; y++)

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -1548,7 +1548,7 @@ static bool do_dungeon(ls_flag_t flag, bool no_companions)
 	do_s16b(&last_teleportation_y, flag);
 
 	/* Spell effects */
-	do_vector(flag, effects,
+	do_array("spell effects", flag, effects, std::size(effects),
 		[](auto effect, auto flag) -> void {
 			do_s16b(&effect->type, flag);
 			do_s16b(&effect->dam, flag);


### PR DESCRIPTION
This should fix #58 which apparently happens when multiple spell effects
are active. When one of them expires the maybe_effect index of another
lasting effect in cave array point past the game->lasting_effects
vector.