### PR TITLE
Fix cave generation

### DIFF
--- a/src/generate.cc
+++ b/src/generate.cc
@@ -3722,6 +3722,9 @@ static void store_height(int x, int y, int x0, int y0, byte val,
 	if (((x == 0) || (y == 0) || (x == xhsize * 2) || (y == yhsize * 2)) &&
 	                (val <= cutoff)) val = cutoff + 1;
 
+	if (val > 216) {
+		val = FEAT_FLOOR;
+	}
 	/* Store the value in height-map format */
 	/* Meant to be temporary, hence no cave_set_feat */
 	cave[y + y0 - yhsize][x + x0 - xhsize].feat = val;


### PR DESCRIPTION
When generating fractal caves cave[y][x].feat is sometimes set to a
negative value which is out of bounds of game.edit_data.f_info vector.
This commit is a workaround for such cases.